### PR TITLE
Fixed tagging

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,31 +50,30 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v2
     - name: Get merged PR
-      uses: actions-ecosystem/action-get-merged-pull-request@v1
+      uses: actions-ecosystem/action-get-merged-pull-request@v1.0.1
       id: get-merged-pull-request
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
     - name: Get release label
-      uses: actions-ecosystem/action-release-label@v1
+      uses: actions-ecosystem/action-release-label@v1.2.0
       id: release-label
       if: ${{ steps.get-merged-pull-request.outputs.title != null }}
       with:
-        github_token: ${{ secrets.GITHUB_TOKEN }}
         labels: ${{ steps.get-merged-pull-request.outputs.labels }}
     - name: Get latest tag
-      uses: actions-ecosystem/action-get-latest-tag@v1
+      uses: actions-ecosystem/action-get-latest-tag@v1.6.0
       id: get-latest-tag
       with:
         semver_only: true
     - name: Bump tag
-      uses: actions-ecosystem/action-bump-semver@v1
+      uses: actions-ecosystem/action-bump-semver@v1.0.0
       id: bump-semver
       if: ${{ steps.release-label.outputs.level != null }}
       with:
         current_version: ${{ steps.get-latest-tag.outputs.tag }}
         level: ${{ steps.release-label.outputs.level }}
     - name: Push tag
-      uses: actions-ecosystem/action-push-tag@v1
+      uses: actions-ecosystem/action-push-tag@v1.0.0
       if: ${{ success() && github.ref == 'refs/heads/master' }}
       with:
         tag: ${{ steps.bump-semver.outputs.new_version }}


### PR DESCRIPTION
Removed github_token input and pinned all actions to patch versions.  A breaking changed was introduced when 1 action was bumped by a minor version.  Repos do not support referencing actions with only major minor