### PR TITLE
Get-PullRequestPolicyEvaluation: expose IsExpired and BuildId

### DIFF
--- a/Tests/U019-Get-PullRequestPolicyEvaluation.Tests.ps1
+++ b/Tests/U019-Get-PullRequestPolicyEvaluation.Tests.ps1
@@ -24,7 +24,9 @@ Describe "Get-PullRequestPolicyEvaluation unit tests" -Tag "Unit" {
                     "status": "approved",
                     "context": {
                         "buildDefinitionId": "9876",
-                        "buildDefinitionName": "foo-build"
+                        "buildDefinitionName": "foo-build",
+                        "buildId": 11192,
+                        "isExpired": true
                     }
                 },
                 {
@@ -50,5 +52,9 @@ Describe "Get-PullRequestPolicyEvaluation unit tests" -Tag "Unit" {
         $Output.GetType().Name | Should -Be "Object[]"
         $Output[0].GetType().Name | Should -Be "PullRequestPolicyEvaluation"
         $Output[0].BuildDefinitionName | Should -Be "foo-build"
+        $Output[0].BuildId | Should -Be 11192
+        $Output[0].IsExpired | Should -Be $true
+        $Output[1].BuildId | Should -Be 0
+        $Output[1].IsExpired | Should -Be $false
     }
 }

--- a/gandt-azure-devops-tools/Classes/PullRequestPolicyEvaluation.ps1
+++ b/gandt-azure-devops-tools/Classes/PullRequestPolicyEvaluation.ps1
@@ -3,4 +3,6 @@ class PullRequestPolicyEvaluation {
     [string]$BuildDefinitionName
     [string]$Status
     [DateTime]$CompletedDate
+    [int]$BuildId
+    [bool]$IsExpired
 }

--- a/gandt-azure-devops-tools/Functions/Public/PullRequest/Get-PullRequestPolicyEvaluation.ps1
+++ b/gandt-azure-devops-tools/Functions/Public/PullRequest/Get-PullRequestPolicyEvaluation.ps1
@@ -71,6 +71,8 @@ function New-PolicyEvaluationStatusObject {
         $PullRequestPolicyEvaluation.BuildDefinitionName = $PolicyEvaluationStatusJson.context.buildDefinitionName
         $PullRequestPolicyEvaluation.Status = $PolicyEvaluationStatusJson.status
         $PullRequestPolicyEvaluation.CompletedDate = $PolicyEvaluationStatusJson.completedDate ? $PolicyEvaluationStatusJson.completedDate : [DateTime]::MinValue
+        $PullRequestPolicyEvaluation.BuildId = $PolicyEvaluationStatusJson.context.buildId ? $PolicyEvaluationStatusJson.context.buildId : 0
+        $PullRequestPolicyEvaluation.IsExpired = [bool]$PolicyEvaluationStatusJson.context.isExpired
 
         $PullRequestPolicyEvaluation
 


### PR DESCRIPTION
## Summary
- Add `IsExpired` and `BuildId` properties to `PullRequestPolicyEvaluation` class
- Map `context.isExpired` and `context.buildId` from policy evaluation response in `New-PolicyEvaluationStatusObject`
- Update U019 unit test fixture and assertions

## Why
ADO marks a PR build policy evaluation as `isExpired=true` once the source branch has been updated after the build ran. The API still reports `status=queued` in that case, so without `IsExpired` callers can't distinguish "build genuinely queued" from "build ran then superseded" — which is what the ADO UI shows as **Expired**.

## Test plan
- [x] U019 unit test passes with new fixture covering both `isExpired=true` (with `buildId`) and the absent case (defaults to `$false` / `0`)
- [x] Verified end-to-end against live PRs in a private ADO project: 16 PRs previously reported as `queued` now correctly surface `IsExpired=True`, matching the UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)