### PR TITLE
Add Invoke-PullRequestPolicyEvaluation

### DIFF
--- a/Tests/U019-Get-PullRequestPolicyEvaluation.Tests.ps1
+++ b/Tests/U019-Get-PullRequestPolicyEvaluation.Tests.ps1
@@ -20,6 +20,7 @@ Describe "Get-PullRequestPolicyEvaluation unit tests" -Tag "Unit" {
         {
             "value": [
                 {
+                    "evaluationId": "aabbccdd-0000-0000-0000-000000000001",
                     "completedDate":  "2017-08-01T21:04:05.787Z",
                     "status": "approved",
                     "context": {
@@ -51,6 +52,7 @@ Describe "Get-PullRequestPolicyEvaluation unit tests" -Tag "Unit" {
         $Output = Get-PullRequestPolicyEvaluation @TestParams
         $Output.GetType().Name | Should -Be "Object[]"
         $Output[0].GetType().Name | Should -Be "PullRequestPolicyEvaluation"
+        $Output[0].EvaluationId | Should -Be "aabbccdd-0000-0000-0000-000000000001"
         $Output[0].BuildDefinitionName | Should -Be "foo-build"
         $Output[0].BuildId | Should -Be 11192
         $Output[0].IsExpired | Should -Be $true

--- a/Tests/U032-Invoke-PullRequestPolicyEvaluation.Tests.ps1
+++ b/Tests/U032-Invoke-PullRequestPolicyEvaluation.Tests.ps1
@@ -1,0 +1,49 @@
+BeforeAll {
+    Push-Location -Path $PSScriptRoot\..\
+    . .\gandt-azure-devops-tools\Functions\Private\Invoke-AzDevOpsRestMethod.ps1
+}
+
+Describe "Invoke-PullRequestPolicyEvaluation unit tests" -Tag "Unit" {
+
+    BeforeEach {
+        $SharedParams = @{
+            Instance     = "notarealinstance"
+            PatToken     = "not-a-real-token"
+            ProjectId    = "notarealproject"
+            EvaluationId = "aabbccdd-0000-0000-0000-000000000001"
+        }
+    }
+
+    It "Will return a PullRequestPolicyEvaluation object after requeue" {
+        $TestJson = @'
+        {
+            "evaluationId": "aabbccdd-0000-0000-0000-000000000001",
+            "status": "queued",
+            "completedDate": "",
+            "context": {
+                "buildDefinitionId": "9876",
+                "buildDefinitionName": "foo-build",
+                "buildId": 0,
+                "isExpired": false
+            }
+        }
+'@
+
+        Mock Invoke-AzDevOpsRestMethod { return ConvertFrom-Json $TestJson }
+
+        . .\gandt-azure-devops-tools\Classes\PullRequestPolicyEvaluation.ps1
+        . .\gandt-azure-devops-tools\Functions\Public\PullRequest\Get-PullRequestPolicyEvaluation.ps1
+        . .\gandt-azure-devops-tools\Functions\Public\PullRequest\Invoke-PullRequestPolicyEvaluation.ps1
+
+        $Output = Invoke-PullRequestPolicyEvaluation @SharedParams
+
+        $Output.GetType().Name | Should -Be "PullRequestPolicyEvaluation"
+        $Output.EvaluationId | Should -Be "aabbccdd-0000-0000-0000-000000000001"
+        $Output.Status | Should -Be "queued"
+        $Output.IsExpired | Should -Be $false
+
+        Should -Invoke Invoke-AzDevOpsRestMethod -Times 1 -ParameterFilter {
+            $HttpMethod -eq "PATCH" -and $ResourceId -eq "aabbccdd-0000-0000-0000-000000000001"
+        }
+    }
+}

--- a/gandt-azure-devops-tools/Classes/PullRequestPolicyEvaluation.ps1
+++ b/gandt-azure-devops-tools/Classes/PullRequestPolicyEvaluation.ps1
@@ -1,4 +1,5 @@
 class PullRequestPolicyEvaluation {
+    [string]$EvaluationId
     [int]$BuildDefinitionId
     [string]$BuildDefinitionName
     [string]$Status

--- a/gandt-azure-devops-tools/Functions/Public/PullRequest/Get-PullRequestPolicyEvaluation.ps1
+++ b/gandt-azure-devops-tools/Functions/Public/PullRequest/Get-PullRequestPolicyEvaluation.ps1
@@ -67,6 +67,7 @@ function New-PolicyEvaluationStatusObject {
 
         $PullRequestPolicyEvaluation = New-Object -TypeName PullRequestPolicyEvaluation
 
+        $PullRequestPolicyEvaluation.EvaluationId = $PolicyEvaluationStatusJson.evaluationId
         $PullRequestPolicyEvaluation.BuildDefinitionId = $PolicyEvaluationStatusJson.context.buildDefinitionId
         $PullRequestPolicyEvaluation.BuildDefinitionName = $PolicyEvaluationStatusJson.context.buildDefinitionName
         $PullRequestPolicyEvaluation.Status = $PolicyEvaluationStatusJson.status

--- a/gandt-azure-devops-tools/Functions/Public/PullRequest/Invoke-PullRequestPolicyEvaluation.ps1
+++ b/gandt-azure-devops-tools/Functions/Public/PullRequest/Invoke-PullRequestPolicyEvaluation.ps1
@@ -1,0 +1,42 @@
+function Invoke-PullRequestPolicyEvaluation {
+    <#
+        .NOTES
+        API Reference: https://learn.microsoft.com/en-us/rest/api/azure/devops/policy/evaluations/requeue-policy-evaluation?view=azure-devops-rest-7.2
+    #>
+    [CmdletBinding()]
+    param (
+        #The Visual Studio Team Services account name
+        [Parameter(Mandatory = $true)]
+        [string]$Instance,
+
+        #A PAT token with the necessary scope to invoke the requested HttpMethod on the specified Resource
+        [Parameter(Mandatory = $true)]
+        [string]$PatToken,
+
+        #The project GUID
+        [Parameter(Mandatory = $true)]
+        [string]$ProjectId,
+
+        #The evaluation ID from a PullRequestPolicyEvaluation object
+        [Parameter(Mandatory = $true)]
+        [string]$EvaluationId
+    )
+
+    process {
+
+        $RequeueParams = @{
+            Instance          = $Instance
+            PatToken          = $PatToken
+            Collection        = $ProjectId
+            Area              = "policy"
+            Resource          = "evaluations"
+            ResourceId        = $EvaluationId
+            ApiVersion        = "7.2-preview.1"
+            HttpMethod        = "PATCH"
+        }
+
+        $PolicyEvaluationJson = Invoke-AzDevOpsRestMethod @RequeueParams
+
+        New-PolicyEvaluationStatusObject -PolicyEvaluationStatusJson $PolicyEvaluationJson
+    }
+}


### PR DESCRIPTION
## Summary
- Add `Invoke-PullRequestPolicyEvaluation` cmdlet — re-queues an expired PR build policy evaluation via `PATCH policy/evaluations/{evaluationId}`
- Add `EvaluationId` property to `PullRequestPolicyEvaluation` class and map it from the API response (required to call the new cmdlet)
- Add U032 unit test verifying the PATCH is called with correct parameters and returns a typed object

## Test plan
- [x] U032 unit test passes
- [x] Verified end-to-end: called against a live expired evaluation on PR 2051, `IsExpired` flipped to `False` and `Status` returned as `queued`

🤖 Generated with [Claude Code](https://claude.com/claude-code)