### PR TITLE
Add Update-PullRequest cmdlet

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,6 +9,11 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 **Branch naming:** UpperCamelCase with no separators (e.g. `MyFeatureBranch`).
 
+**Commit messages:** Plain imperative, no conventional-commits prefix.
+- New cmdlet: `Add <CmdletName>` or `Add <CmdletName>; <extra detail>`
+- Modified cmdlet: `<CmdletName>: <what changed>`
+- Other: imperative verb + description (`Remove ...`, `Upgrade ...`)
+
 **Worktrees:** Create in `../gandt-azure-devops-tools-worktrees/<branch-name>/` — never inside this directory.
 
 ## Running Tests

--- a/gandt-azure-devops-tools/Functions/Public/PullRequest/Update-PullRequest.ps1
+++ b/gandt-azure-devops-tools/Functions/Public/PullRequest/Update-PullRequest.ps1
@@ -1,0 +1,55 @@
+function Update-PullRequest {
+    <#
+        .NOTES
+        API Reference: https://learn.microsoft.com/en-us/rest/api/azure/devops/git/pull-requests/update?view=azure-devops-rest-7.0
+
+        Permissions: PAT token requires Contribute to Pull Requests on the repository.
+    #>
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $true)]
+        [string]$Instance,
+
+        [Parameter(Mandatory = $true)]
+        [string]$PatToken,
+
+        [Parameter(Mandatory = $true)]
+        [string]$ProjectId,
+
+        [Parameter(Mandatory = $true)]
+        [string]$RepositoryId,
+
+        [Parameter(Mandatory = $true)]
+        [int]$PullRequestId,
+
+        [string]$Title,
+        [string]$Description,
+        [nullable[bool]]$IsDraft,
+        [string]$TargetBranchRef
+    )
+
+    $Body = @{}
+
+    if ($PSBoundParameters.ContainsKey('Title'))         { $Body['title']         = $Title }
+    if ($PSBoundParameters.ContainsKey('Description'))   { $Body['description']   = $Description }
+    if ($PSBoundParameters.ContainsKey('IsDraft'))       { $Body['isDraft']       = $IsDraft }
+    if ($PSBoundParameters.ContainsKey('TargetBranchRef')) { $Body['targetRefName'] = $TargetBranchRef }
+
+    $Params = @{
+        Instance             = $Instance
+        PatToken             = $PatToken
+        Collection           = $ProjectId
+        Area                 = "git"
+        Resource             = "repositories"
+        ResourceId           = $RepositoryId
+        ResourceComponent    = "pullrequests"
+        ResourceComponentId  = $PullRequestId
+        ApiVersion           = "7.0"
+        HttpMethod           = "PATCH"
+        HttpBody             = $Body
+    }
+
+    $PullRequestJson = Invoke-AzDevOpsRestMethod @Params
+
+    New-PullRequestObject -PullRequestJson $PullRequestJson
+}


### PR DESCRIPTION
## Summary

- Adds `Update-PullRequest` cmdlet wrapping the ADO PATCH pull requests endpoint
- Supports updating title, description, draft status, and target branch
- Only fields explicitly passed are included in the request body — omitted params leave the PR unchanged